### PR TITLE
Add remaining non-keypad instructions

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -11,7 +11,7 @@ pub struct VirtualMachine {
     pub memory: [u8; MEM_SIZE],
     pub video_memory: [[u8; DISPLAY_WIDTH]; DISPLAY_HEIGHT],
     pub program_counter: usize,
-    pub stack: Vec<u16>,
+    pub stack: Vec<usize>,
     pub i_register: usize,
     pub variable_registers: [u8; 16],
     pub delay_timer: u8,
@@ -88,7 +88,9 @@ impl VirtualMachine {
             }
             // Return from subroutine
             [0x0, 0x0, 0xE, 0xE] => {
-                self.program_counter = self.stack.pop().unwrap() as usize;
+                if let Some(addr) = self.stack.pop() {
+                    self.program_counter = addr;
+                }
             }
             // Jump to address
             [0x1, _, _, _] => {
@@ -96,7 +98,7 @@ impl VirtualMachine {
             }
             // Call subroutine
             [0x2, _, _, _] => {
-                self.stack.push(self.program_counter as u16);
+                self.stack.push(self.program_counter);
                 self.program_counter = nnn;
             }
             // Skip if VX = kk
@@ -143,60 +145,40 @@ impl VirtualMachine {
             }
             // Set VX = VX + VY
             [0x8, _, _, 0x4] => {
-                let add_option = self.variable_registers[x]
-                    .checked_add(self.variable_registers[y]);
+                let (sum, is_overflow) = self.variable_registers[x]
+                    .overflowing_add(self.variable_registers[y]);
 
-                match add_option {
-                    Some(sum) => {
-                        self.variable_registers[0xF] = 0;
-                        self.variable_registers[x] = sum;
-                    }
-                    None => {
-                        // overflow
-                        self.variable_registers[0xF] = 1;
-                        let overflowed_sum = self.variable_registers[x] as u16
-                            + self.variable_registers[y] as u16;
-                        self.variable_registers[x] =
-                            (overflowed_sum & 0xFF) as u8;
-                    }
-                }
+                self.variable_registers[0xF] = is_overflow as u8;
+
+                self.variable_registers[x] = sum;
             }
             // Set VX = VX - VY
             [0x8, _, _, 0x5] => {
-                if self.variable_registers[x] > self.variable_registers[y] {
-                    self.variable_registers[0xF] = 1;
-                    self.variable_registers[x] -= self.variable_registers[y];
-                    return;
-                }
+                let (diff, is_underflow) = self.variable_registers[x]
+                    .overflowing_sub(self.variable_registers[y]);
 
-                // underflow
-                self.variable_registers[0xF] = 0;
-                let underflowed_difference = self.variable_registers[x]
-                    + (0xFF - self.variable_registers[y]);
-                self.variable_registers[x] = underflowed_difference;
+                self.variable_registers[0xF] = is_underflow as u8;
+
+                self.variable_registers[x] = diff;
             }
             // Set VX = VX >> 1
             [0x8, _, _, 0x6] => {
+                // TODO: handle ambiguous behaviour
                 self.variable_registers[0xF] = self.variable_registers[x] & 0x1;
                 self.variable_registers[x] >>= 1;
             }
             // Set VX = VY - VX
             [0x8, _, _, 0x7] => {
-                if self.variable_registers[y] > self.variable_registers[x] {
-                    self.variable_registers[0xF] = 1;
-                    self.variable_registers[x] =
-                        self.variable_registers[y] - self.variable_registers[x];
-                    return;
-                }
+                let (diff, is_underflow) = self.variable_registers[y]
+                    .overflowing_sub(self.variable_registers[x]);
 
-                // underflow
-                self.variable_registers[0xF] = 0;
-                let underflowed_difference = self.variable_registers[y]
-                    + (0xFF - self.variable_registers[x]);
-                self.variable_registers[x] = underflowed_difference;
+                self.variable_registers[0xF] = is_underflow as u8;
+
+                self.variable_registers[x] = diff;
             }
             // Set VX = VX << 1
             [0x8, _, _, 0xE] => {
+                // TODO: handle ambiguous behaviour
                 self.variable_registers[0xF] =
                     (self.variable_registers[x] & 0x80) >> 7;
                 self.variable_registers[x] <<= 1;
@@ -213,6 +195,7 @@ impl VirtualMachine {
             }
             // Jump to nnn + V0
             [0xB, _, _, _] => {
+                // TODO: handle ambiguous behaviour
                 self.program_counter =
                     self.variable_registers[0] as usize + nnn;
             }
@@ -278,6 +261,7 @@ impl VirtualMachine {
             }
             // Set I = I + VX
             [0xF, _, 0x1, 0xE] => {
+                // TODO: handle ambiguous behaviour
                 self.i_register += self.variable_registers[x] as usize;
             }
             // Set I = location of sprite for VX

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -264,7 +264,7 @@ impl VirtualMachine {
             [0xF, _, 0x0, 0x7] => {
                 self.variable_registers[x] = self.delay_timer;
             }
-            // Wait for a key press, store value in Vx
+            // Wait for a key press, store value in VX
             [0xF, _, 0x0, 0xA] => {
                 // TODO: when keypad is implemented
             }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,6 +1,7 @@
 pub mod consts;
 
 use consts::*;
+use notan::random::rand;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
@@ -10,11 +11,11 @@ pub struct VirtualMachine {
     pub memory: [u8; MEM_SIZE],
     pub video_memory: [[u8; DISPLAY_WIDTH]; DISPLAY_HEIGHT],
     pub program_counter: usize,
-    pub _stack: Vec<u16>,
+    pub stack: Vec<u16>,
     pub i_register: usize,
     pub variable_registers: [u8; 16],
-    pub _delay_timer: u8,
-    pub _sound_timer: u8,
+    pub delay_timer: u8,
+    pub sound_timer: u8,
 }
 
 impl VirtualMachine {
@@ -32,11 +33,11 @@ impl VirtualMachine {
             memory,
             video_memory: [[0; DISPLAY_WIDTH]; DISPLAY_HEIGHT],
             program_counter: PROG_MEM_START_ADDR,
-            _stack: Vec::with_capacity(STACK_SIZE),
+            stack: Vec::with_capacity(STACK_SIZE),
             i_register: 0,
             variable_registers: [0; 16],
-            _delay_timer: 0,
-            _sound_timer: 0,
+            delay_timer: 0,
+            sound_timer: 0,
         }
     }
 
@@ -85,9 +86,36 @@ impl VirtualMachine {
             [0x0, 0x0, 0xE, 0x0] => {
                 self.video_memory = [[0; DISPLAY_WIDTH]; DISPLAY_HEIGHT];
             }
+            // Return from subroutine
+            [0x0, 0x0, 0xE, 0xE] => {
+                self.program_counter = self.stack.pop().unwrap() as usize;
+            }
             // Jump to address
             [0x1, _, _, _] => {
                 self.program_counter = nnn;
+            }
+            // Call subroutine
+            [0x2, _, _, _] => {
+                self.stack.push(self.program_counter as u16);
+                self.program_counter = nnn;
+            }
+            // Skip if VX = kk
+            [0x3, _, _, _] => {
+                if self.variable_registers[x] == kk {
+                    self.program_counter += 2;
+                }
+            }
+            // Skip if VX != kk
+            [0x4, _, _, _] => {
+                if self.variable_registers[x] != kk {
+                    self.program_counter += 2;
+                }
+            }
+            // Skip if VX == VY
+            [0x5, _, _, 0x0] => {
+                if self.variable_registers[x] == self.variable_registers[y] {
+                    self.program_counter += 2;
+                }
             }
             // Set register VX
             [0x6, _, _, _] => {
@@ -97,9 +125,100 @@ impl VirtualMachine {
             [0x7, _, _, _] => {
                 self.variable_registers[x] += kk;
             }
+            // Set VX = VY
+            [0x8, _, _, 0x0] => {
+                self.variable_registers[x] = self.variable_registers[y];
+            }
+            // Set VX = VX | VY
+            [0x8, _, _, 0x1] => {
+                self.variable_registers[x] |= self.variable_registers[y];
+            }
+            // Set VX = VX & VY
+            [0x8, _, _, 0x2] => {
+                self.variable_registers[x] &= self.variable_registers[y];
+            }
+            // Set VX = VX ^ VY
+            [0x8, _, _, 0x3] => {
+                self.variable_registers[x] ^= self.variable_registers[y];
+            }
+            // Set VX = VX + VY
+            [0x8, _, _, 0x4] => {
+                let add_option = self.variable_registers[x]
+                    .checked_add(self.variable_registers[y]);
+
+                match add_option {
+                    Some(sum) => {
+                        self.variable_registers[0xF] = 0;
+                        self.variable_registers[x] = sum;
+                    }
+                    None => {
+                        // overflow
+                        self.variable_registers[0xF] = 1;
+                        let overflowed_sum = self.variable_registers[x] as u16
+                            + self.variable_registers[y] as u16;
+                        self.variable_registers[x] =
+                            (overflowed_sum & 0xFF) as u8;
+                    }
+                }
+            }
+            // Set VX = VX - VY
+            [0x8, _, _, 0x5] => {
+                if self.variable_registers[x] > self.variable_registers[y] {
+                    self.variable_registers[0xF] = 1;
+                    self.variable_registers[x] -= self.variable_registers[y];
+                    return;
+                }
+
+                // underflow
+                self.variable_registers[0xF] = 0;
+                let underflowed_difference = self.variable_registers[x]
+                    + (0xFF - self.variable_registers[y]);
+                self.variable_registers[x] = underflowed_difference;
+            }
+            // Set VX = VX >> 1
+            [0x8, _, _, 0x6] => {
+                self.variable_registers[0xF] = self.variable_registers[x] & 0x1;
+                self.variable_registers[x] >>= 1;
+            }
+            // Set VX = VY - VX
+            [0x8, _, _, 0x7] => {
+                if self.variable_registers[y] > self.variable_registers[x] {
+                    self.variable_registers[0xF] = 1;
+                    self.variable_registers[x] =
+                        self.variable_registers[y] - self.variable_registers[x];
+                    return;
+                }
+
+                // underflow
+                self.variable_registers[0xF] = 0;
+                let underflowed_difference = self.variable_registers[y]
+                    + (0xFF - self.variable_registers[x]);
+                self.variable_registers[x] = underflowed_difference;
+            }
+            // Set VX = VX << 1
+            [0x8, _, _, 0xE] => {
+                self.variable_registers[0xF] =
+                    (self.variable_registers[x] & 0x80) >> 7;
+                self.variable_registers[x] <<= 1;
+            }
+            // Skip if VY != VY
+            [0x9, _, _, 0x0] => {
+                if self.variable_registers[x] != self.variable_registers[y] {
+                    self.program_counter += 2;
+                }
+            }
             // Set index register I
             [0xA, _, _, _] => {
                 self.i_register = nnn;
+            }
+            // Jump to nnn + V0
+            [0xB, _, _, _] => {
+                self.program_counter =
+                    self.variable_registers[0] as usize + nnn;
+            }
+            // Set VX = random byte && kk
+            [0xC, _, _, _] => {
+                self.variable_registers[x] = rand::random::<u8>() & kk;
             }
             // Draw to screen
             [0xD, _, _, _] => {
@@ -131,6 +250,61 @@ impl VirtualMachine {
 
                         *display_pixel ^= sprite_pixel;
                     }
+                }
+            }
+            // Skip if VX key is pressed
+            [0xE, _, 0x9, 0xE] => {
+                // TODO: when keypad is implemented
+            }
+            // Skip if VX key is NOT pressed
+            [0xE, _, 0xA, 0x1] => {
+                // TODO: when keypad is implemented
+            }
+            // Set VX = delay timer value
+            [0xF, _, 0x0, 0x7] => {
+                self.variable_registers[x] = self.delay_timer;
+            }
+            // Set delay timer = VX
+            [0xF, _, 0x1, 0x5] => {
+                self.delay_timer = self.variable_registers[x];
+            }
+            // Set sound timer = VX
+            [0xF, _, 0x1, 0x8] => {
+                self.sound_timer = self.variable_registers[x];
+            }
+            // Set I = I + VX
+            [0xF, _, 0x1, 0xE] => {
+                self.i_register += self.variable_registers[x] as usize;
+            }
+            // Set I = location of sprite for VX
+            [0xF, _, 0x2, 0x9] => {
+                let digit = self.variable_registers[x];
+                self.i_register = FONTSET_START_ADDR + (5 * digit) as usize;
+            }
+            // Store BCD of VX in I, I+1, I+2
+            [0xF, _, 0x3, 0x3] => {
+                let mut value = self.variable_registers[x];
+
+                self.memory[self.i_register + 2] = value % 10;
+                value /= 10;
+
+                self.memory[self.i_register + 1] = value % 10;
+                value /= 10;
+
+                self.memory[self.i_register] = value % 10;
+            }
+            // Store V0 through VX starting at I
+            [0xF, _, 0x5, 0x5] => {
+                for i in 0..=self.variable_registers[x] as usize {
+                    self.memory[self.i_register + i] =
+                        self.variable_registers[i];
+                }
+            }
+            // Read V0 through VX starting at I
+            [0xF, _, 0x6, 0x5] => {
+                for i in 0..=self.variable_registers[x] as usize {
+                    self.variable_registers[i] =
+                        self.memory[self.i_register + i];
                 }
             }
             // Unknown instruction

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -149,7 +149,6 @@ impl VirtualMachine {
                     .overflowing_add(self.variable_registers[y]);
 
                 self.variable_registers[0xF] = is_overflow as u8;
-
                 self.variable_registers[x] = sum;
             }
             // Set VX = VX - VY
@@ -158,7 +157,6 @@ impl VirtualMachine {
                     .overflowing_sub(self.variable_registers[y]);
 
                 self.variable_registers[0xF] = is_underflow as u8;
-
                 self.variable_registers[x] = diff;
             }
             // Set VX = VX >> 1
@@ -173,7 +171,6 @@ impl VirtualMachine {
                     .overflowing_sub(self.variable_registers[x]);
 
                 self.variable_registers[0xF] = is_underflow as u8;
-
                 self.variable_registers[x] = diff;
             }
             // Set VX = VX << 1

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -264,6 +264,10 @@ impl VirtualMachine {
             [0xF, _, 0x0, 0x7] => {
                 self.variable_registers[x] = self.delay_timer;
             }
+            // Wait for a key press, store value in Vx
+            [0xF, _, 0x0, 0xA] => {
+                // TODO: when keypad is implemented
+            }
             // Set delay timer = VX
             [0xF, _, 0x1, 0x5] => {
                 self.delay_timer = self.variable_registers[x];


### PR DESCRIPTION
Added the following instructions:
- 00EE - RET - Return from a subroutine
- 2nnn - CALL addr - Call subroutine at nnn
- 3xkk - SE Vx, byte - Skip next instruction if Vx = kk
- 4xkk - SNE Vx, byte - Skip next instruction if Vx != kk
- 5xy0 - SE Vx, Vy - Skip next instruction if Vx = Vy
- 8xy0 - LD Vx, Vy - Set Vx = Vy
- 8xy1 - OR Vx, Vy - Set Vx = Vx OR Vy
- 8xy2 - AND Vx, Vy - Set Vx = Vx AND Vy
- 8xy3 - XOR Vx, Vy - Set Vx = Vx XOR Vy
- 8xy4 - ADD Vx, Vy - Set Vx = Vx + Vy, set VF = carry
- 8xy5 - SUB Vx, Vy - Set Vx = Vx - Vy, set VF = NOT borrow
- 8xy6 - SHR Vx - Set Vx = Vx SHR 1
- 8xy7 - SUBN Vx, Vy - Set Vx = Vy - Vx, set VF = NOT borrow
- 8xyE - SHL Vx {, Vy} - Set Vx = Vx SHL 1
- 9xy0 - SNE Vx, Vy - Skip next instruction if Vx != Vy
- Bnnn - JP V0, addr - Jump to location nnn + V0
- Cxkk - RND Vx, byte - Set Vx = random byte AND kk
- Fx07 - LD Vx, DT - Set Vx = delay timer value
- Fx15 - LD DT, Vx - Set delay timer = Vx
- Fx18 - LD ST, Vx - Set sound timer = Vx
- Fx1E - ADD I, Vx - Set I = I + Vx
- Fx29 - LD F, Vx - Set I = location of sprite for digit Vx
- Fx33 - LD B, Vx - Store BCD representation of Vx in memory locations I, I+1, and I+2
- Fx55 - LD [I], Vx - Store registers V0 through Vx in memory starting at location I
- Fx65 - LD Vx, [I] - Read registers V0 through Vx from memory starting at location I

Added no-op handling of these instructions:
- Ex9E - SKP Vx - Skip next instruction if key with the value of Vx is pressed
- ExA1 - SKNP Vx - Skip next instruction if key with the value of Vx is not pressed
- Fx0A - LD Vx, K - Wait for a key press, store the value of the key in Vx